### PR TITLE
Fixed crash bug when tapping scrollview while refreshing

### DIFF
--- a/HackerNews/MainViewController.swift
+++ b/HackerNews/MainViewController.swift
@@ -26,7 +26,7 @@ class MainViewController: UIViewController, UITableViewDataSource, UITableViewDe
   let DefaultStoryType = StoryType.Top
   
   var firebase: Firebase!
-  var stories: [Story]!
+  var stories: [Story]! = []
   var storyType: StoryType!
   var retrievingStories: Bool!
   var refreshControl: UIRefreshControl!
@@ -88,7 +88,6 @@ class MainViewController: UIViewController, UITableViewDataSource, UITableViewDe
     }
     
     UIApplication.sharedApplication().networkActivityIndicatorVisible = true
-    stories = []
     retrievingStories = true
     var storiesMap = [Int:Story]()
     


### PR DESCRIPTION
## What is this?
When the scrollview is loading, if you tap on a cell or attempt to scroll, you will get a fatal error with because of an index that's out-of-bounds. 
See Issue #30  

## What did I do?
The stories array was being cleared whenever retrieveStories() was called. 
I removed the line of code that did that.
I also initialized stories to [] at declaration